### PR TITLE
Fix error with babel presets

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,8 @@
   },
   "babel": {
     "presets": [
-      "react-app"
+        ["babel-preset-react-app", false],
+        "babel-preset-react-app/prod"
     ]
   }
 }


### PR DESCRIPTION
Related to this issue: https://github.com/facebook/create-react-app/issues/12070
```
Parsing error: [BABEL]  Using `babel-preset-react-app` requires that you specify `NODE_ENV` or `BABEL_ENV` environment variables. Valid values are "development", "test", and "production". Instead, received: undefined. (While processing: "/Users/sasha/.../node_modules/babel-preset-react-app/index.js")
```
Added the suggested fix to the `package.json` and it silences the error and keeps eslint up and running